### PR TITLE
Updated the description of PxSceneDesc::solverType to refer to a correct enum value

### DIFF
--- a/physx/include/PxSceneDesc.h
+++ b/physx/include/PxSceneDesc.h
@@ -632,7 +632,7 @@ public:
 	/**
 	\brief Selects the solver algorithm to use.
 
-	<b>Default:</b> PxSolverType::eDEFAULT
+	<b>Default:</b> PxSolverType::ePGS
 
 	@see PxSolverType
 	*/


### PR DESCRIPTION
Is currently incorrectly referring to "PxSolverType::eDEFAULT" when nu such enum value exists. Seems like "PxSolverType::ePGS" is the actual default value.