### PR TITLE
run multiple sim steps so PVD can be updated

### DIFF
--- a/physx/snippets/snippetloadcollection/SnippetLoadCollection.cpp
+++ b/physx/snippets/snippetloadcollection/SnippetLoadCollection.cpp
@@ -418,7 +418,7 @@ int snippetMain(int argc, const char *const* argv)
 	if (firstCollection)
 		firstCollection->release();
 	
-	for( PxU32 j = 0; j < 50; J++)
+	for( PxU32 j = 0; j < 50; j++)
 	{
 		gScene->simulate(1.0f/60.0f);
 		gScene->fetchResults(true);

--- a/physx/snippets/snippetloadcollection/SnippetLoadCollection.cpp
+++ b/physx/snippets/snippetloadcollection/SnippetLoadCollection.cpp
@@ -417,9 +417,12 @@ int snippetMain(int argc, const char *const* argv)
 
 	if (firstCollection)
 		firstCollection->release();
-
-	gScene->simulate(1.0f/60.0f);
-	gScene->fetchResults(true);
+	
+	for( PxU32 j = 0; j < 50; J++)
+	{
+		gScene->simulate(1.0f/60.0f);
+		gScene->fetchResults(true);
+	}
 
 	cleanupPhysics();	
 


### PR DESCRIPTION
PVD is used to visualize this snippet. I assume the connection to PVD is buffered and when you create only one frame, the connection gets killed before the buffer is flushed and sent out to PVD.