### PR TITLE
Fix issue if there exist white spaces in path under windows

### DIFF
--- a/physx/buildtools/cmake_generate_projects.py
+++ b/physx/buildtools/cmake_generate_projects.py
@@ -311,8 +311,8 @@ def presetProvided(pName):
         # run the cmake script
         #print('Cmake params:' + cmakeParams)
         os.chdir(os.path.join(os.environ['PHYSX_ROOT_DIR'], outputDir))
-        os.system(cmakeExec + ' ' +
-                  os.environ['PHYSX_ROOT_DIR'] + '/compiler/' + cmakeMasterDir + cmakeParams)
+        os.system(cmakeExec + ' \"' + os.environ['PHYSX_ROOT_DIR'] + '/compiler/' +
+                      cmakeMasterDir + '\"' + cmakeParams)
         os.chdir(os.environ['PHYSX_ROOT_DIR'])
     else:
         configs = ['debug', 'checked', 'profile', 'release']

--- a/physx/generate_projects.bat
+++ b/physx/generate_projects.bat
@@ -12,8 +12,8 @@ SET PM_PXSHARED_PATH=%PHYSX_ROOT_DIR%/../pxshared
 SET PM_TARGA_PATH=%PHYSX_ROOT_DIR%/../externals/targa
 SET PM_PATHS=%PM_CMAKEMODULES_PATH%;%PM_TARGA_PATH%
 
-if exist %PHYSX_ROOT_DIR%/../externals/cmake/x64/bin/cmake.exe (
-    SET PM_CMAKE_PATH=%PHYSX_ROOT_DIR%/../externals/cmake/x64
+if exist "%PHYSX_ROOT_DIR%/../externals/cmake/x64/bin/cmake.exe" (
+    SET PM_CMAKE_PATH="%PHYSX_ROOT_DIR%/../externals/cmake/x64"
     GOTO CMAKE_EXTERNAL    
 )
 
@@ -43,14 +43,14 @@ if "%PM_python_PATH%" == "" (
 
 IF %1.==. GOTO ADDITIONAL_PARAMS_MISSING
 
-for /f "usebackq tokens=*" %%i in (`%PM_vswhere_PATH%\VsWhere.exe -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`"%PM_vswhere_PATH%\VsWhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
 	set InstallDir=%%i
 	set VS150PATH="%%i"		
 )	
 
 :ADDITIONAL_PARAMS_MISSING
 pushd %~dp0
-%PM_PYTHON% %PHYSX_ROOT_DIR%/buildtools/cmake_generate_projects.py %1
+%PM_PYTHON% "%PHYSX_ROOT_DIR%/buildtools/cmake_generate_projects.py" %1
 popd
 if %ERRORLEVEL% neq 0 (
     set /p DUMMY=Hit ENTER to continue...

--- a/physx/source/common/include/windows/CmWindowsLoadLibrary.h
+++ b/physx/source/common/include/windows/CmWindowsLoadLibrary.h
@@ -31,6 +31,10 @@
 #ifndef CM_WINDOWS_LOADLIBRARY_H
 #define CM_WINDOWS_LOADLIBRARY_H
 
+#include "PxPhysXConfig.h"
+#if /*PX_SUPPORT_GPU_PHYSX | */!PX_PHYSX_STATIC_LIB
+
+
 #include "foundation/PxPreprocessor.h"
 #include "windows/PxWindowsDelayLoadHook.h"
 #include "windows/PsWindowsInclude.h"
@@ -57,7 +61,7 @@ namespace Cm
 		return retVal;
 #else
 		return ::LoadLibraryA( name );
-#endif		
+#endif
 	};
 
 	PX_INLINE FARPROC WINAPI physXCommonDliNotePreLoadLibrary(const char* libraryName, const physx::PxDelayLoadHook* delayLoadHook)
@@ -83,5 +87,6 @@ namespace Cm
 } // namespace Cm
 } // namespace physx
 
+#endif  // PX_SUPPORT_GPU_PHYSX | !PX_PHYSX_STATIC_LIB
 
 #endif	// CM_WINDOWS_LOADLIBRARY_H

--- a/physx/source/common/src/windows/CmWindowsDelayLoadHook.cpp
+++ b/physx/source/common/src/windows/CmWindowsDelayLoadHook.cpp
@@ -27,6 +27,8 @@
 // Copyright (c) 2004-2008 AGEIA Technologies, Inc. All rights reserved.
 // Copyright (c) 2001-2004 NovodeX AG. All rights reserved.  
 
+#include "PxPhysXConfig.h"
+#if /*PX_SUPPORT_GPU_PHYSX |*/ !PX_PHYSX_STATIC_LIB
 
 #include "windows/PxWindowsDelayLoadHook.h"
 #include "windows/PsWindowsInclude.h"
@@ -80,3 +82,4 @@ FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli)
 }
 
 PfnDliHook __pfnDliNotifyHook2 = delayHook;
+#endif  // PX_SUPPORT_GPU_PHYSX | !PX_PHYSX_STATIC_LIB

--- a/physx/source/common/src/windows/CmWindowsModuleUpdateLoader.cpp
+++ b/physx/source/common/src/windows/CmWindowsModuleUpdateLoader.cpp
@@ -79,7 +79,11 @@ static void LogMessage(PXUL_ErrorCode messageType, char* message)
 CmModuleUpdateLoader::CmModuleUpdateLoader(const char* updateLoaderDllName)
 	: mGetUpdatedModuleFunc(NULL)
 {
+#if /*PX_SUPPORT_GPU_PHYSX |*/ !PX_PHYSX_STATIC_LIB
 	mUpdateLoaderDllHandle = loadLibrary(updateLoaderDllName);
+#else
+    PX_UNUSED(updateLoaderDllName);
+#endif
 
 	if (mUpdateLoaderDllHandle != NULL)
 	{
@@ -111,7 +115,8 @@ HMODULE CmModuleUpdateLoader::LoadModule(const char* moduleName, const char* app
 {
 	HMODULE result = NULL;
 
-	if (mGetUpdatedModuleFunc != NULL)
+#if /*PX_SUPPORT_GPU_PHYSX |*/ !PX_PHYSX_STATIC_LIB
+    if (mGetUpdatedModuleFunc != NULL)
 	{
 		// Try to get the module through PhysXUpdateLoader
 		GetUpdatedModule_FUNC getUpdatedModuleFunc = (GetUpdatedModule_FUNC)mGetUpdatedModuleFunc;
@@ -119,9 +124,13 @@ HMODULE CmModuleUpdateLoader::LoadModule(const char* moduleName, const char* app
 	}
 	else
 	{
-		// If no PhysXUpdateLoader, just load the DLL directly
+        // If no PhysXUpdateLoader, just load the DLL directly
 		result = loadLibrary(moduleName);
 	}
+#else
+    PX_UNUSED(appGUID);
+    PX_UNUSED(moduleName);
+#endif
 
 	return result;
 }

--- a/physx/source/compiler/cmake/windows/CMakeLists.txt
+++ b/physx/source/compiler/cmake/windows/CMakeLists.txt
@@ -28,6 +28,7 @@
 OPTION(PX_COPY_EXTERNAL_DLL "Copy external dlls into SDK bin directory" OFF)
 OPTION(PX_FLOAT_POINT_PRECISE_MATH "Float point precise math" OFF)
 OPTION(PX_USE_NVTX "Enabled NVTX profiling" OFF)
+OPTION(PX_DISABLE_CUDA_PHYSX "Disable CUDA PhysX" OFF)
 
 # We define the CXX flags for this CMakeLists and all others that are included afterwards. This is a GLOBAL setting. 
 # If/when the solutions go standalone (say, samples and visual tests) - those CMakeLists will need to be fixed.
@@ -89,6 +90,10 @@ IF(PX_USE_NVTX)
 	SET(NVTX_FLAG "PX_NVTX=1")
 ELSE()
 	SET(NVTX_FLAG "PX_NVTX=0")
+ENDIF()
+
+IF(PX_DISABLE_CUDA_PHYSX)
+  SET(CUDA_FLAG "DISABLE_CUDA_PHYSX")
 ENDIF()
 
 SET(PHYSX_WINDOWS_COMPILE_DEFS "WIN32;${WIN64_FLAG};${SCALAR_MATH_FLAG};${CUDA_FLAG};_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;${PHYSX_AUTOBUILD};${PHYSX_AUTOBUILDNUMBER}" CACHE INTERNAL "Base PhysX preprocessor definitions")

--- a/physx/source/foundation/src/windows/PsWindowsThread.cpp
+++ b/physx/source/foundation/src/windows/PsWindowsThread.cpp
@@ -130,8 +130,12 @@ uint32_t ThreadImpl::getNbPhysicalCores()
 		DWORD processorCoreCount = 0;
 		DWORD byteOffset = 0;
 
+#if !PX_UWP
+		// TODO: Fails for uwp
 		glpi = (LPFN_GLPI)GetProcAddress(GetModuleHandle(TEXT("kernel32")), "GetLogicalProcessorInformation");
-
+#else
+		glpi = NULL;
+#endif
 		if(NULL == glpi)
 		{
 			// GetLogicalProcessorInformation not supported on OS < XP Service Pack 3
@@ -280,9 +284,11 @@ void ThreadImpl::quit()
 
 void ThreadImpl::kill()
 {
-	if(getThread(this)->state == _ThreadImpl::Started)
+#if !PX_UWP
+	if (getThread(this)->state == _ThreadImpl::Started)
 		TerminateThread(getThread(this)->thread, 0);
 	getThread(this)->state = _ThreadImpl::Stopped;
+#endif
 }
 
 void ThreadImpl::sleep(uint32_t ms)

--- a/physx/source/physx/src/device/windows/PhysXIndicatorWindows.cpp
+++ b/physx/source/physx/src/device/windows/PhysXIndicatorWindows.cpp
@@ -58,11 +58,14 @@ physx::PhysXIndicator::PhysXIndicator(bool isGpu)
 		Windows XP				5.1
 		Windows 2000			5.0
 	**/
-	
 	char configName[128];
 
 #if _MSC_VER >= 1800
+#if !PX_UWP
 	if (!IsWindowsVistaOrGreater())
+#else
+    if(true)
+#endif
 #else
 	OSVERSIONINFOEX windowsVersionInfo;
 	windowsVersionInfo.dwOSVersionInfoSize = sizeof (windowsVersionInfo);
@@ -73,10 +76,16 @@ physx::PhysXIndicator::PhysXIndicator(bool isGpu)
 		NvPhysXToDrv_Build_SectionNameXP(GetCurrentProcessId(), configName);
 	else
 		NvPhysXToDrv_Build_SectionName(GetCurrentProcessId(), configName);
-	
-	mFileHandle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL,
-		PAGE_READWRITE, 0, sizeof(NvPhysXToDrv_Data_V1), configName);
 
+#if PX_UWP
+    wchar_t wConfigName[128];
+    mbstowcs(&wConfigName[0], configName, strlen(configName));
+	mFileHandle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL,
+		PAGE_READWRITE, 0, sizeof(NvPhysXToDrv_Data_V1), wConfigName);
+#else
+    mFileHandle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL,
+        PAGE_READWRITE, 0, sizeof(NvPhysXToDrv_Data_V1), configName);
+#endif
 	if (!mFileHandle || mFileHandle == INVALID_HANDLE_VALUE)
 		return;
 

--- a/physx/source/physx/src/gpu/PxPhysXGpuModuleLoader.cpp
+++ b/physx/source/physx/src/gpu/PxPhysXGpuModuleLoader.cpp
@@ -104,11 +104,12 @@ namespace physx
 
 #define DEFAULT_PHYSX_GPU_GUID    "D79FA4BF-177C-4841-8091-4375D311D6A3"
 
-	void PxLoadPhysxGPUModule(const char* appGUID)
+#if !PX_PHYSX_GPU_STATIC
+    void PxLoadPhysxGPUModule(const char* appGUID)
 	{
 		static HMODULE s_library;
 
-		if (s_library == NULL)
+        if (s_library == NULL)
 			s_library = GetModuleHandle(gPhysXGpuLibraryName);
 
 		if (s_library == NULL)
@@ -142,6 +143,7 @@ namespace physx
 		g_PxSetPhysXGpuDelayLoadHook_Func(PxGetPhysXDelayLoadHook());
 
 	}
+#endif
 
 #elif PX_LINUX
 

--- a/physx/source/physx/src/windows/NpWindowsDelayLoadHook.cpp
+++ b/physx/source/physx/src/windows/NpWindowsDelayLoadHook.cpp
@@ -27,6 +27,8 @@
 // Copyright (c) 2004-2008 AGEIA Technologies, Inc. All rights reserved.
 // Copyright (c) 2001-2004 NovodeX AG. All rights reserved.  
 
+#include "PxPhysXConfig.h"
+#if /*PX_SUPPORT_GPU_PHYSX | */!PX_PHYSX_STATIC_LIB
 
 #include "windows/PxWindowsDelayLoadHook.h"
 #include "windows/PsWindowsInclude.h"
@@ -88,3 +90,4 @@ FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli)
 }
 
 PfnDliHook __pfnDliNotifyHook2 = delayHook;
+#endif

--- a/physx/source/physxcooking/src/windows/WindowsCookingDelayLoadHook.cpp
+++ b/physx/source/physxcooking/src/windows/WindowsCookingDelayLoadHook.cpp
@@ -27,6 +27,8 @@
 // Copyright (c) 2004-2008 AGEIA Technologies, Inc. All rights reserved.
 // Copyright (c) 2001-2004 NovodeX AG. All rights reserved.  
 
+#include "PxPhysXConfig.h"
+#if /*PX_SUPPORT_GPU_PHYSX |*/ !PX_PHYSX_STATIC_LIB
 
 #include "windows/PxWindowsDelayLoadHook.h"
 #include "windows/PsWindowsInclude.h"
@@ -45,6 +47,7 @@ void physx::PxSetPhysXCookingDelayLoadHook(const physx::PxDelayLoadHook* hook)
 
 using namespace physx;
 
+// only necessary if gpu (dll) or physx is build als dll
 #pragma comment(lib, "delayimp")
 
 FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli)
@@ -80,3 +83,4 @@ FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli)
 }
 
 PfnDliHook __pfnDliNotifyHook2 = delayHook;
+#endif


### PR DESCRIPTION
generate_projects fails if the path contains any whitespaces.
This should help to fix this on window systems