### PR TITLE
Fix for alpha=0x00 with PxVisualizationParameter::eBODY_MASS_AXES

### DIFF
--- a/physx/source/physx/src/NpRigidDynamic.cpp
+++ b/physx/source/physx/src/NpRigidDynamic.cpp
@@ -568,6 +568,7 @@ void NpRigidDynamic::visualize(Cm::RenderOutput& out, NpScene* npScene)
 			PxReal sleepTime = getScbBodyFast().getWakeCounter() / npScene->getWakeCounterResetValueInteral();
 			PxU32 color = PxU32(0xff * (sleepTime>1.0f ? 1.0f : sleepTime));
 			color = getScbBodyFast().isSleeping() ? 0xff0000 : (color<<16 | color<<8 | color);
+			color = 0xff000000 | color;
 			PxVec3 dims = invertDiagInertia(getScbBodyFast().getInverseInertia());
 			dims = getDimsFromBodyInertia(dims, 1.0f / getScbBodyFast().getInverseMass());
 


### PR DESCRIPTION
Reference: https://github.com/NVIDIAGameWorks/PhysX/issues/131