### PR TITLE
Fixed crash due to race condition

### DIFF
--- a/physx/source/simulationcontroller/src/ScScene.cpp
+++ b/physx/source/simulationcontroller/src/ScScene.cpp
@@ -6089,7 +6089,8 @@ void Sc::Scene::finishBroadPhaseStage2(const PxU32 ccdPass)
 						{
 							Sc::ShapeInteraction* si = static_cast<Sc::ShapeInteraction*>(interaction);
 							mNPhaseCore->lostTouchReports(si, PxU32(PairReleaseFlag::eWAKE_ON_LOST_TOUCH), 0, outputs, useAdaptiveForce);
-							si->destroyManager();
+							if (si->getContactManager())
+								si->destroyManager();
 							si->clearIslandGenData();
 						}
 


### PR DESCRIPTION
We have a rare crash in PhysX when simulating certain amount of convex meshes on our scene. Sometimes it crashes when destroying contact manager (since it was already destroyed).
Check source change file for the reference.
A call to `si->destroyManager();` in `void Sc::Scene::finishBroadPhaseStage2(PxBaseTask*)` happens after a call to `si->destroyManager();` in `void Sc::Scene::destroyManagers(PxBaseTask*)`
Proper fix might be more complicated than the one in my pull request, but this fixed a crash for us
