### PR TITLE
Fixed compatibility with VS 16.3

### DIFF
--- a/physx/source/foundation/include/PsAllocator.h
+++ b/physx/source/foundation/include/PsAllocator.h
@@ -37,7 +37,11 @@
 
 #if(PX_WINDOWS_FAMILY || PX_XBOXONE)
 	#include <exception>
+#if(_MSC_VER >= 1923)
+	#include <typeinfo>
+#else
 	#include <typeinfo.h>
+#endif
 #endif
 #if(PX_APPLE_FAMILY)
 	#include <typeinfo>


### PR DESCRIPTION
Proof:
https://developercommunity.visualstudio.com/content/problem/734566/msvc-142328019-is-missing-include-typeinfoh.html
The same change should be applied to 3.4.