### PR TITLE
Change typeinfo.h to typeinfo

### DIFF
--- a/physx/source/foundation/include/PsAllocator.h
+++ b/physx/source/foundation/include/PsAllocator.h
@@ -35,9 +35,13 @@
 #include "PxFoundation.h"
 #include "Ps.h"
 
-#if(PX_WINDOWS_FAMILY || PX_XBOXONE)
+#if(PX_XBOXONE)
 	#include <exception>
 	#include <typeinfo.h>
+#endif
+#if(PX_WINDOWS_FAMILY)
+	#include <exception>
+	#include <typeinfo>
 #endif
 #if(PX_APPLE_FAMILY)
 	#include <typeinfo>


### PR DESCRIPTION
Fixes #164. 

Visual Studio 16.3.1 shipped with MSVC tools version 14.23.28105, which no longer includes typeinfo.h. [Microsoft confirmed this is an intentional choice, and not a bug](https://developercommunity.visualstudio.com/content/problem/734566/msvc-142328019-is-missing-include-typeinfoh.html?childToView=736370#comment-736370):

> We have removed this ancient, non-Standard header. Its Standard replacement is typeinfo.

`typeinfo` exists on 14.22.27905, the previous version of the MSVC toolset. I have not verified the existence of `typeinfo` in any earlier versions of the toolset.

## Testing
1. Built ALL_BUILD
2. Ran about 5 or 6 of the samples and snippets, all seemed to work.

## Directory listings of typeinfo* in the two toolset versions

```cmd
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC>dir "%VSINSTALLDIR%\VC\Tools\MSVC"
 Volume in drive C is SSD
 Volume Serial Number is 7CC7-C9ED

 Directory of C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC

09/25/19  23:55    <DIR>          .
09/25/19  23:55    <DIR>          ..
09/25/19  23:55    <DIR>          14.22.27905
09/25/19  09:51    <DIR>          14.23.28105
               0 File(s)              0 bytes
               4 Dir(s)  156,573,806,592 bytes free

C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC>dir "%VSINSTALLDIR%\VC\Tools\MSVC\14.22.27905\include\typeinfo*"
 Volume in drive C is SSD
 Volume Serial Number is 7CC7-C9ED

 Directory of C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\include

09/25/19  23:55             2,501 typeinfo
09/25/19  23:55               641 typeinfo.h
               2 File(s)          3,142 bytes
               0 Dir(s)  156,573,732,864 bytes free

C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC>dir "%VSINSTALLDIR%\VC\Tools\MSVC\14.23.28105\include\typeinfo*"
 Volume in drive C is SSD
 Volume Serial Number is 7CC7-C9ED

 Directory of C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.23.28105\include

09/25/19  09:46             2,630 typeinfo
               1 File(s)          2,630 bytes
               0 Dir(s)  156,573,609,984 bytes free
```