### PR TITLE
Fixed rare crash in Vermintide 2

### DIFF
--- a/physx/source/geomutils/src/gjk/GuEPAFacet.h
+++ b/physx/source/geomutils/src/gjk/GuEPAFacet.h
@@ -46,7 +46,7 @@
 
 namespace physx
 {
-#define MaxEdges 32
+#define MaxEdges 64
 #define MaxFacets 64
 #define MaxSupportPoints 64
 


### PR DESCRIPTION
This crash was pulled in here https://github.com/NVIDIAGameWorks/PhysX-3.4/pull/69, but it's not available in PhysX 4.x