### PR TITLE
CMake: Make PRIVATE geomutils include directories

### DIFF
--- a/physx/source/compiler/cmake/PhysXCooking.cmake
+++ b/physx/source/compiler/cmake/PhysXCooking.cmake
@@ -128,19 +128,19 @@ TARGET_INCLUDE_DIRECTORIES(PhysXCooking
 	PRIVATE ${PHYSX_SOURCE_DIR}/common/include
 	PRIVATE ${PHYSX_SOURCE_DIR}/common/src
 	
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/include
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/contact
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/common
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/convex
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/distance
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/sweep
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/gjk
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/intersection
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/mesh
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/hf
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/pcm
-	PUBLIC ${PHYSX_SOURCE_DIR}/geomutils/src/ccd
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/include
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/contact
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/common
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/convex
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/distance
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/sweep
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/gjk
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/intersection
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/mesh
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/hf
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/pcm
+	PRIVATE ${PHYSX_SOURCE_DIR}/geomutils/src/ccd
 
 	PRIVATE ${PHYSX_SOURCE_DIR}/physxcooking/src
 	PRIVATE ${PHYSX_SOURCE_DIR}/physxcooking/src/mesh


### PR DESCRIPTION
Change from PUBLIC to PRIVATE the inclusion of directories related to
geomutils in PhysXCooking.

Preliminary tests in linux are successful, without build or linking errors

Fixes #216