### PR TITLE
Change header typeinfo.h for <typeinfo> in Windows

### DIFF
--- a/physx/source/foundation/include/PsAllocator.h
+++ b/physx/source/foundation/include/PsAllocator.h
@@ -35,12 +35,9 @@
 #include "PxFoundation.h"
 #include "Ps.h"
 
+#include <typeinfo>
 #if(PX_WINDOWS_FAMILY || PX_XBOXONE)
 	#include <exception>
-	#include <typeinfo.h>
-#endif
-#if(PX_APPLE_FAMILY)
-	#include <typeinfo>
 #endif
 
 #include <new>


### PR DESCRIPTION
The header typeinfo.h was removed in msvc 16.3
https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#standard-library-improvements-1

<typeinfo> is standardized since forever, expect compatibility with old compilers.