### PR TITLE
use HashMap to make PxBinaryConverter faster

### DIFF
--- a/physx/source/physxextensions/src/serialization/Binary/SnConvX.h
+++ b/physx/source/physxextensions/src/serialization/Binary/SnConvX.h
@@ -34,7 +34,7 @@
 
 #include "CmPhysXCommon.h"
 #include "PsUserAllocated.h"
-#include "PsArray.h"
+#include "PsHashMap.h"
 #include "SnConvX_Common.h"
 #include "SnConvX_Union.h"
 #include "SnConvX_MetaData.h"
@@ -58,13 +58,8 @@ namespace Sn {
 		void	setObjectRef(PxU64 object64, PxU32 ref);
 		bool	getObjectRef(PxU64 object64, PxU32& ref)	const;
 
-		struct InternalData
-		{
-			PxU64	object;
-			PxU32	id;
-		};
-
-		Ps::Array<InternalData>	mData;
+		typedef Ps::HashMap<PxU64, PxU32> PointerMap;
+		PointerMap mData;
 	};
 
 	class Handle16Remap
@@ -76,13 +71,8 @@ namespace Sn {
 		void	setObjectRef(PxU16 object, PxU16 ref);
 		bool	getObjectRef(PxU16 object, PxU16& ref)	const;
 
-		struct InternalData
-		{
-			PxU16	object;
-			PxU16	id;
-		};
-
-		Ps::Array<InternalData>	mData;
+		typedef Ps::HashMap<PxU16, PxU16> Handle16Map;
+		Handle16Map mData;
 	};
 
 	class ConvX : public physx::PxBinaryConverter, public shdfnd::UserAllocated

--- a/physx/source/physxextensions/src/serialization/Binary/SnConvX_Convert.cpp
+++ b/physx/source/physxextensions/src/serialization/Binary/SnConvX_Convert.cpp
@@ -1218,32 +1218,18 @@ PointerRemap::~PointerRemap()
 
 void PointerRemap::setObjectRef(PxU64 object64, PxU32 ref)
 {
-	const PxU32 size = mData.size();
-	for(PxU32 i=0;i<size;i++)
-	{
-		if(mData[i].object==object64)
-		{
-			mData[i].id = ref;
-			return;
-		}
-	}
-	InternalData data;
-	data.object	= object64;
-	data.id		= ref;
-	mData.pushBack(data);
+	mData[object64] = ref;
 }
 
 bool PointerRemap::getObjectRef(PxU64 object64, PxU32& ref) const
 {	
-	const PxU32 size = mData.size();
-	for(PxU32 i=0;i<size;i++)
+	const PointerMap::Entry* entry = mData.find(object64);
+	if (NULL != entry)
 	{
-		if(mData[i].object==object64)
-		{
-			ref = mData[i].id;
-			return true;
-		}
+		ref = entry->second;
+		return true;
 	}
+
 	return false;
 }
 
@@ -1257,32 +1243,18 @@ Handle16Remap::~Handle16Remap()
 
 void Handle16Remap::setObjectRef(PxU16 object, PxU16 ref)
 {
-	const PxU32 size = mData.size();
-	for(PxU32 i=0;i<size;i++)
-	{
-		if(mData[i].object==object)
-		{
-			mData[i].id = ref;
-			return;
-		}
-	}
-	InternalData data;
-	data.object	= object;
-	data.id		= ref;
-	mData.pushBack(data);
+	mData[object] = ref;
 }
 
 bool Handle16Remap::getObjectRef(PxU16 object, PxU16& ref) const
 {	
-	const PxU32 size = mData.size();
-	for(PxU32 i=0;i<size;i++)
+	const Handle16Map::Entry* entry = mData.find(object);
+	if (NULL != entry)
 	{
-		if(mData[i].object==object)
-		{
-			ref = mData[i].id;
-			return true;
-		}
+		ref = entry->second;
+		return true;
 	}
+
 	return false;
 }
 


### PR DESCRIPTION
I use PxBinaryConverter to convert a PxCollection that holding about 2 million PxActors from Win64 format to Linux64 format.
It tooks me 9 hours.
Profiling shows that 99.5% of CPU time is consumed by PointerRemap::getObjectRef.
This patch reduced the conversion time from 9 hours to 120 seconds.