### PR TITLE
out of bounds array indexing fixed in cmpool.h

### DIFF
--- a/physx/source/common/src/CmPool.h
+++ b/physx/source/common/src/CmPool.h
@@ -149,7 +149,7 @@ public:
 					T** slabs = reinterpret_cast<T**>(Alloc::allocate(2* newSlabCount *sizeof(T*), __FILE__, __LINE__));
 					if (mSlabs)
 					{
-						PxMemCopy(slabs, mSlabs, sizeof(T*)*newSlabCount);
+						PxMemCopy(slabs, mSlabs, sizeof(T*)*mSlabCount);
 
 						Alloc::deallocate(mSlabs);
 					}


### PR DESCRIPTION
in the preallocate function
PxMemCopy(slabs, mSlabs, sizeof(T*) * newSlabCount);
has the problem of out of bounds array indexing.
this should be changed to
PxMemCopy(slabs, mSlabs, sizeof(T*) * mSlabCount);