### PR TITLE
Fix const argument in PxTransform operator

### DIFF
--- a/pxshared/include/foundation/PxTransform.h
+++ b/pxshared/include/foundation/PxTransform.h
@@ -96,7 +96,7 @@ class PxTransform
 	}
 
 	//! Equals matrix multiplication
-	PX_CUDA_CALLABLE PX_INLINE PxTransform& operator*=(PxTransform& other)
+	PX_CUDA_CALLABLE PX_INLINE PxTransform& operator*=(const PxTransform& other)
 	{
 		*this = *this * other;
 		return *this;


### PR DESCRIPTION
Fixes errors with some compilers when using a const right side operand.