### PR TITLE
add include for PxVehicleUtil.h

### DIFF
--- a/physx/include/PxPhysicsAPI.h
+++ b/physx/include/PxPhysicsAPI.h
@@ -202,6 +202,7 @@ Alternatively, one can instead directly #include a subset of the below files.
 #include "vehicle/PxVehicleShaders.h"
 #include "vehicle/PxVehicleTireFriction.h"
 #include "vehicle/PxVehicleUpdate.h"
+#include "vehicle/PxVehicleUtil.h"
 #include "vehicle/PxVehicleUtilControl.h"
 #include "vehicle/PxVehicleUtilSetup.h"
 #include "vehicle/PxVehicleUtilTelemetry.h"


### PR DESCRIPTION
For the longest time I was wondering why `PxVehicleIsInAir` was inaccessible, until I saw this in the 4W snippet:
```
#include "PxPhysicsAPI.h"

#include "vehicle/PxVehicleUtil.h"
```

The only function in PxVehicleUtil.h is `PxVehicleIsInAir`. Seeing as how it's [listed in the docs](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/group__vehicle.html#gae7390efc088e2d8624da2ba007bfbb6e), I think this header is worthy of including in PxPhysicsAPI.h.