### PR TITLE
fix emscripten compile error

### DIFF
--- a/physx/source/foundation/include/PsHash.h
+++ b/physx/source/foundation/include/PsHash.h
@@ -87,7 +87,7 @@ PX_FORCE_INLINE uint32_t hash(const uint64_t key)
 	return uint32_t(UINT32_MAX & k);
 }
 
-#if PX_APPLE_FAMILY
+#if PX_APPLE_FAMILY || __EMSCRIPTEN__
 // hash for size_t, to make gcc happy
 PX_INLINE uint32_t hash(const size_t key)
 {


### PR DESCRIPTION
Without this directive, Emscripten (WebAssembly compiler) crashes and burns.

```
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHash.h:127:10: error: call to 'hash' is ambiguous
                return hash(k);
                       ^~~~
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHashInternals.h:319:10: note: in instantiation of member function 'physx::shdfnd::Hash<unsigned long>::operator()' requested here
                return HashFn()(k) & (hashSize - 1);
                       ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHashInternals.h:391:18: note: in instantiation of member function 'physx::shdfnd::internal::HashBase<physx::shdfnd::Pair<const unsigned long, physx::Sn::SerialObjectIndex>, unsigned long, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::internal::HashMapBase<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::GetKey, physx::shdfnd::NonTrackingAllocator, true>::hash' requested here
                                uint32_t h = hash(GetKey()(mEntries[index]), newHashSize);
                                             ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHashInternals.h:66:4: note: in instantiation of member function 'physx::shdfnd::internal::HashBase<physx::shdfnd::Pair<const unsigned long, physx::Sn::SerialObjectIndex>, unsigned long, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::internal::HashMapBase<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::GetKey, physx::shdfnd::NonTrackingAllocator, true>::reserveInternal' requested here
                        reserveInternal(initialTableSize);
                        ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHashInternals.h:74:3: note: in instantiation of member function 'physx::shdfnd::internal::HashBase<physx::shdfnd::Pair<const unsigned long, physx::Sn::SerialObjectIndex>, unsigned long, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::internal::HashMapBase<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::GetKey, physx::shdfnd::NonTrackingAllocator, true>::init' requested here
                init(initialTableSize, loadFactor);
                ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHashInternals.h:724:74: note: in instantiation of member function 'physx::shdfnd::internal::HashBase<physx::shdfnd::Pair<const unsigned long, physx::Sn::SerialObjectIndex>, unsigned long, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::internal::HashMapBase<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::GetKey, physx::shdfnd::NonTrackingAllocator, true>::HashBase' requested here
        HashMapBase(uint32_t initialTableSize = 64, float loadFactor = 0.75f) : mBase(initialTableSize, loadFactor)
                                                                                ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHashMap.h:106:4: note: in instantiation of member function 'physx::shdfnd::internal::HashMapBase<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::HashMapBase' requested here
        : HashMapBase(initialTableSize, loadFactor)
          ^
/home/fonsi/physx.js/PhysX/physx/source/common/src/CmCollection.h:56:8: note: in instantiation of member function 'physx::shdfnd::CoalescedHashMap<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::CoalescedHashMap' requested here
                            Ps::CoalescedHashMap< Key, Value, HashFn, Allocator>(initialTableSize,loadFactor) {}
                            ^
/home/fonsi/physx.js/PhysX/physx/source/physxextensions/src/serialization/Binary/SnSerializationContext.h:257:4: note: in instantiation of member function 'physx::Cm::CollectionHashMap<unsigned long, physx::Sn::SerialObjectIndex, physx::shdfnd::Hash<unsigned long>, physx::shdfnd::NonTrackingAllocator>::CollectionHashMap' requested here
                        SerializationContext(const Cm::Collection& collection, const Cm::Collection* externalRefs) 
                        ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHash.h:57:26: note: candidate function
PX_FORCE_INLINE uint32_t hash(const uint32_t key)
                         ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHash.h:69:26: note: candidate function
PX_FORCE_INLINE uint32_t hash(const int32_t key)
                         ^
/home/fonsi/physx.js/PhysX/physx/source/foundation/include/PsHash.h:76:26: note: candidate function
PX_FORCE_INLINE uint32_t hash(const uint64_t key)
                         ^
1 error generated.
```