### PR TITLE
Place BpBroadPhaseMBP symbols in an internal namespace.

### DIFF
--- a/physx/source/lowlevelaabb/src/BpBroadPhaseMBP.cpp
+++ b/physx/source/lowlevelaabb/src/BpBroadPhaseMBP.cpp
@@ -90,6 +90,8 @@ using namespace Cm;
 		return ir;
 	}*/
 
+namespace internalMBP {
+
 struct RegionHandle : public Ps::UserAllocated
 {
 	PxU16	mHandle;			// Handle from region
@@ -581,6 +583,10 @@ struct RegionData : public Ps::UserAllocated
 	}
 	#endif
 #endif
+
+}
+
+using namespace internalMBP;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/physx/source/lowlevelaabb/src/BpBroadPhaseMBP.h
+++ b/physx/source/lowlevelaabb/src/BpBroadPhaseMBP.h
@@ -35,8 +35,10 @@
 #include "BpBroadPhaseMBPCommon.h"
 #include "BpMBPTasks.h"
 
+namespace internalMBP {
 	class MBP;
-	
+}
+
 namespace physx
 {
 namespace Bp
@@ -84,7 +86,7 @@ namespace Bp
 				MBPUpdateWorkTask			mMBPUpdateWorkTask;
 				MBPPostUpdateWorkTask		mMBPPostUpdateWorkTask;
 
-				MBP*						mMBP;		// PT: TODO: aggregate
+				internalMBP::MBP*			mMBP;		// PT: TODO: aggregate
 
 				MBP_Handle*					mMapping;
 				PxU32						mCapacity;


### PR DESCRIPTION
The class `BitArray` conflicts with a class of the same name in the 3ds Max SDK and will cause link errors if using a static PhysX SDK. Additionally, another version of `BitArray` can be found in BpBroadPhaseABP.cpp, except it is inside of an `internalABP` namespace. Therefore, I have moved all of the symbols in BpBroadPaseMBP from the global namespace into an `internalMBP` namespace to prevent these link-time collisions.