### PR TITLE
Fix compilation warnings when building samples

### DIFF
--- a/physx/samples/sampleframework/renderer/src/d3d11/D3D11RendererMemoryMacros.h
+++ b/physx/samples/sampleframework/renderer/src/d3d11/D3D11RendererMemoryMacros.h
@@ -44,10 +44,10 @@ template<class T>
 PX_INLINE bool dxReleaseAndReturnTrue( T& t ) { dxSafeRelease(t); return true; }
 
 template<class T>
-PX_INLINE void deleteAll( T& t ) { std::remove_if(t.begin(), t.end(), deleteAndReturnTrue<typename T::value_type>); };
+PX_INLINE void deleteAll( T& t ) { static_cast<void>(std::remove_if(t.begin(), t.end(), deleteAndReturnTrue<typename T::value_type>)); };
 
 template<class T>
-PX_INLINE void dxSafeReleaseAll( T& t ) { std::remove_if(t.begin(), t.end(), dxReleaseAndReturnTrue<typename T::value_type>); };
+PX_INLINE void dxSafeReleaseAll( T& t ) { static_cast<void>(std::remove_if(t.begin(), t.end(), dxReleaseAndReturnTrue<typename T::value_type>)); };
 
 template<class T>
 PX_INLINE void resizeIfSmallerThan( T& t, typename T::size_type s, typename T::value_type v = typename T::value_type() ) 

--- a/physx/samples/sampleframework/renderer/src/d3d11/D3D11RendererResourceManager.h
+++ b/physx/samples/sampleframework/renderer/src/d3d11/D3D11RendererResourceManager.h
@@ -144,6 +144,7 @@ private:
 		virtual const std::type_info& type_info() const = 0;
 		virtual Proxy *clone() const = 0;
 		virtual void release() = 0;
+		virtual ~Proxy() { };
 #if !USE_ANY_AS_CONTAINER
 		virtual bool operator<(const Proxy&) const = 0;
 		virtual bool operator==(const Proxy&) const = 0;


### PR DESCRIPTION
Platform: Windows 10, Visual Studio 2019

This PR fixes compilation warnings in sample rendering code. It was preventing the compilation to work out of the box because of warnings treated as errors.

```
physx\samples\sampleframework\renderer\src\d3d11\D3D11RendererResourceManager.h(53,11): warning C5205: delete of an abstract class 'SampleRenderer::Any::Proxy' that has a non-virtual destructor results in undefined behavior
```

```
physx\samples\sampleframework\renderer\src\d3d11\D3D11RendererMemoryMacros.h(50,48): warning C4834: discarding return value of function with 'nodiscard' attribute
```