### PR TITLE
[physx/source] Remove undefined behaviour from offset calclucations

### DIFF
--- a/physx/source/physx/src/NpArticulationJoint.h
+++ b/physx/source/physx/src/NpArticulationJoint.h
@@ -76,6 +76,7 @@ public:
 
 	PX_INLINE	const Scb::ArticulationJoint&	getScbArticulationJoint() const { return mJoint; }
 	PX_INLINE	Scb::ArticulationJoint&			getScbArticulationJoint()		{ return mJoint; }
+	static PX_INLINE size_t						getScbArticulationJointOffset()	{ return PX_OFFSET_OF(PxArticulationJointImpl, mJoint); }
 
 	PX_INLINE	PxArticulationLink&				getParentArticulationLink() const;
 	PX_INLINE	PxArticulationLink&				getChildArticulationLink() const;

--- a/physx/source/physx/src/NpArticulationTemplate.h
+++ b/physx/source/physx/src/NpArticulationTemplate.h
@@ -122,6 +122,7 @@ public:
 
 	PX_FORCE_INLINE	Scb::Articulation&			getScbArticulation() { return mArticulation; }
 	PX_FORCE_INLINE	const Scb::Articulation&	getScbArticulation() const { return mArticulation; }
+	static PX_FORCE_INLINE size_t				getScbArticulationOffset() { return PX_OFFSET_OF(PxArticulationImpl, mArticulation); }
 
 	PX_FORCE_INLINE	void						increaseCacheVersion()	{ mCacheVersion++; }
 

--- a/physx/source/physx/src/NpConstraint.h
+++ b/physx/source/physx/src/NpConstraint.h
@@ -108,6 +108,7 @@ public:
 					NpScene*						getSceneFromActors() const;
 	PX_FORCE_INLINE	Scb::Constraint&				getScbConstraint()				{ return mConstraint; }
 	PX_FORCE_INLINE	const Scb::Constraint&			getScbConstraint() const		{ return mConstraint; }
+	static PX_FORCE_INLINE size_t					getScbConstraintOffset()		{ return PX_OFFSET_OF(NpConstraint, mConstraint); }
 	PX_FORCE_INLINE	bool							isDirty() const					{ return mIsDirty; }
 
 

--- a/physx/source/physx/src/NpPhysics.cpp
+++ b/physx/source/physx/src/NpPhysics.cpp
@@ -151,15 +151,15 @@ void NpPhysics::initOffsetTables(PxvOffsetTable& pxvOffsetTable)
 	// init offset tables for Pxs/Sc/Scb/Px conversions
 	{
 		Sc::OffsetTable& offsetTable =  Sc::gOffsetTable;
-		offsetTable.scRigidStatic2PxActor				= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpRigidStatic*>(0)->getScbRigidStaticFast())) - static_cast<ptrdiff_t>(Scb::RigidStatic::getScOffset());
-		offsetTable.scRigidDynamic2PxActor				= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpRigidDynamic*>(0)->getScbBodyFast()))		- static_cast<ptrdiff_t>(Scb::Body::getScOffset());
-		offsetTable.scArticulationLink2PxActor			= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpArticulationLink*>(0)->getScbBodyFast()))	- static_cast<ptrdiff_t>(Scb::Body::getScOffset());
-		offsetTable.scArticulationMC2Px					= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpArticulation*>(0)->mImpl.getScbArticulation()))	- static_cast<ptrdiff_t>(Scb::Articulation::getScOffset());
-		offsetTable.scArticulationRC2Px					= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpArticulationReducedCoordinate*>(0)->mImpl.getScbArticulation())) - static_cast<ptrdiff_t>(Scb::Articulation::getScOffset());
-		offsetTable.scArticulationJointMC2Px			= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpArticulationJoint*>(0)->mImpl.getScbArticulationJoint()))	- static_cast<ptrdiff_t>(Scb::ArticulationJoint::getScOffset());
-		offsetTable.scArticulationJointRC2Px			= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpArticulationJointReducedCoordinate*>(0)->mImpl.getScbArticulationJoint())) - static_cast<ptrdiff_t>(Scb::ArticulationJoint::getScOffset());
-		offsetTable.scConstraint2Px						= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpConstraint*>(0)->getScbConstraint()))		- static_cast<ptrdiff_t>(Scb::Constraint::getScOffset());
-		offsetTable.scShape2Px							= -reinterpret_cast<ptrdiff_t>(&(reinterpret_cast<NpShape*>(0)->getScbShape()))					- static_cast<ptrdiff_t>(Scb::Shape::getScOffset());
+		offsetTable.scRigidStatic2PxActor				= -static_cast<ptrdiff_t>(NpRigidStatic::getScbRigidStaticOffset()) - static_cast<ptrdiff_t>(Scb::RigidStatic::getScOffset());
+		offsetTable.scRigidDynamic2PxActor				= -static_cast<ptrdiff_t>(NpRigidDynamic::getScbBodyOffset())		- static_cast<ptrdiff_t>(Scb::Body::getScOffset());
+		offsetTable.scArticulationLink2PxActor			= -static_cast<ptrdiff_t>(NpArticulationLink::getScbBodyOffset())	- static_cast<ptrdiff_t>(Scb::Body::getScOffset());
+		offsetTable.scArticulationMC2Px					= -static_cast<ptrdiff_t>(PxArticulationImpl::getScbArticulationOffset())	- static_cast<ptrdiff_t>(Scb::Articulation::getScOffset());
+		offsetTable.scArticulationRC2Px					= -static_cast<ptrdiff_t>(PxArticulationImpl::getScbArticulationOffset()) - static_cast<ptrdiff_t>(Scb::Articulation::getScOffset());
+		offsetTable.scArticulationJointMC2Px			= -static_cast<ptrdiff_t>(PxArticulationJointImpl::getScbArticulationJointOffset())	- static_cast<ptrdiff_t>(Scb::ArticulationJoint::getScOffset());
+		offsetTable.scArticulationJointRC2Px			= -static_cast<ptrdiff_t>(PxArticulationJointImpl::getScbArticulationJointOffset()) - static_cast<ptrdiff_t>(Scb::ArticulationJoint::getScOffset());
+		offsetTable.scConstraint2Px						= -static_cast<ptrdiff_t>(NpConstraint::getScbConstraintOffset())	- static_cast<ptrdiff_t>(Scb::Constraint::getScOffset());
+		offsetTable.scShape2Px							= -static_cast<ptrdiff_t>(NpShape::getScbShapeOffset())				- static_cast<ptrdiff_t>(Scb::Shape::getScOffset());
 
 		for(PxU32 i=0;i<PxActorType::eACTOR_COUNT;i++)
 			offsetTable.scCore2PxActor[i] = 0;
@@ -169,9 +169,9 @@ void NpPhysics::initOffsetTables(PxvOffsetTable& pxvOffsetTable)
 	}
 	{
 		Sc::OffsetTable& scOffsetTable = Sc::gOffsetTable;
-		pxvOffsetTable.pxsShapeCore2PxShape			= scOffsetTable.scShape2Px				- reinterpret_cast<ptrdiff_t>(&static_cast<Sc::ShapeCore*>(0)->getCore());
-		pxvOffsetTable.pxsRigidCore2PxRigidBody		= scOffsetTable.scRigidDynamic2PxActor	- reinterpret_cast<ptrdiff_t>(&static_cast<Sc::BodyCore*>(0)->getCore());
-		pxvOffsetTable.pxsRigidCore2PxRigidStatic	= scOffsetTable.scRigidStatic2PxActor	- reinterpret_cast<ptrdiff_t>(&static_cast<Sc::StaticCore*>(0)->getCore());
+		pxvOffsetTable.pxsShapeCore2PxShape			= scOffsetTable.scShape2Px				- static_cast<ptrdiff_t>(Sc::ShapeCore::getCoreOffset());
+		pxvOffsetTable.pxsRigidCore2PxRigidBody		= scOffsetTable.scRigidDynamic2PxActor	- static_cast<ptrdiff_t>(Sc::BodyCore::getCoreOffset());
+		pxvOffsetTable.pxsRigidCore2PxRigidStatic	= scOffsetTable.scRigidStatic2PxActor	- static_cast<ptrdiff_t>(Sc::StaticCore::getCoreOffset());
 	}
 }
 

--- a/physx/source/physx/src/NpRigidBodyTemplate.h
+++ b/physx/source/physx/src/NpRigidBodyTemplate.h
@@ -110,6 +110,8 @@ public:
 	PX_FORCE_INLINE	const Scb::Body&	getScbBodyFast()		const	{ return mBody;			}	// PT: important: keep returning an address here (else update prefetch in SceneQueryManager::addShapes)
 	PX_FORCE_INLINE	Scb::Body&			getScbBodyFast()				{ return mBody;			}	// PT: important: keep returning an address here (else update prefetch in SceneQueryManager::addShapes)
 
+	static PX_FORCE_INLINE size_t		getScbBodyOffset()				{ return PX_OFFSET_OF(NpRigidBodyTemplate, mBody);	}
+
 	PX_FORCE_INLINE	Scb::Actor&			getScbActorFast()				{ return mBody;			}
 	PX_FORCE_INLINE	const Scb::Actor&	getScbActorFast()		const	{ return mBody;			}
 

--- a/physx/source/physx/src/NpRigidStatic.h
+++ b/physx/source/physx/src/NpRigidStatic.h
@@ -98,6 +98,7 @@ public:
 
 	PX_FORCE_INLINE	const Scb::RigidStatic&	getScbRigidStaticFast()	const	{ return mRigidStatic;	}
 	PX_FORCE_INLINE	Scb::RigidStatic&		getScbRigidStaticFast()			{ return mRigidStatic;	}
+	PX_FORCE_INLINE	static std::size_t		getScbRigidStaticOffset()		{ return PX_OFFSET_OF(NpRigidStatic, mRigidStatic);	}
 
 	PX_FORCE_INLINE	const PxTransform&		getGlobalPoseFast()		const	{ return mRigidStatic.getActor2World();	}
 

--- a/physx/source/physx/src/NpShape.h
+++ b/physx/source/physx/src/NpShape.h
@@ -184,6 +184,7 @@ public:
 
 	PX_FORCE_INLINE	const Scb::Shape&			getScbShape()			const	{ return mShape;	}
 	PX_FORCE_INLINE	Scb::Shape&					getScbShape()					{ return mShape;	}
+	static PX_FORCE_INLINE size_t				getScbShapeOffset()				{ return PX_OFFSET_OF(NpShape, mShape);	}
 
 	PX_INLINE		PxMaterial*					getMaterial(PxU32 index) const { return mShape.getMaterial(index); }
 	static			bool						checkMaterialSetup(const PxGeometry& geom, const char* errorMsgPrefix, PxMaterial*const* materials, PxU16 materialCount);

--- a/physx/source/physx/src/buffering/ScbActor.cpp
+++ b/physx/source/physx/src/buffering/ScbActor.cpp
@@ -38,8 +38,8 @@ using namespace Scb;
 
 Actor::Offsets::Offsets()
 {
-	const size_t staticOffset	= reinterpret_cast<size_t>(&(reinterpret_cast<Scb::RigidStatic*>(0)->getScStatic()));
-	const size_t bodyOffset		= reinterpret_cast<size_t>(&(reinterpret_cast<Scb::Body*>(0)->getScBody()));
+	const size_t staticOffset	= Scb::RigidStatic::getScOffset();
+	const size_t bodyOffset		= Scb::Body::getScOffset();
 
 	scToScb[PxActorType::eRIGID_STATIC] = staticOffset;
 	scToScb[PxActorType::eRIGID_DYNAMIC] = bodyOffset;

--- a/physx/source/physx/src/buffering/ScbArticulation.h
+++ b/physx/source/physx/src/buffering/ScbArticulation.h
@@ -151,7 +151,7 @@ public:
 	PX_FORCE_INLINE static Articulation&		fromSc(Core &a)					{ return *reinterpret_cast<Articulation*>(reinterpret_cast<PxU8*>(&a)-getScOffset()); }
 	PX_FORCE_INLINE static const Articulation&	fromSc(const Core &a)			{ return *reinterpret_cast<const Articulation*>(reinterpret_cast<const PxU8*>(&a)-getScOffset()); }
 
-	static size_t getScOffset()	{ return reinterpret_cast<size_t>(&reinterpret_cast<Articulation*>(0)->mArticulation);	}
+	static size_t getScOffset()	{ return PX_OFFSET_OF(Articulation, mArticulation);	}
 
 	PX_FORCE_INLINE	void		wakeUpInternal(PxReal wakeCounter);
 

--- a/physx/source/physx/src/buffering/ScbArticulationJoint.h
+++ b/physx/source/physx/src/buffering/ScbArticulationJoint.h
@@ -245,7 +245,7 @@ public:
 	PX_FORCE_INLINE Core&				getScArticulationJoint()				{ return mJoint; }  // Only use if you know what you're doing!
 
 
-	static			size_t				getScOffset()							{ return reinterpret_cast<size_t>(&reinterpret_cast<ArticulationJoint*>(0)->mJoint);	}
+	static			size_t				getScOffset()							{ return PX_OFFSET_OF(ArticulationJoint, mJoint);	}
 
 	PX_FORCE_INLINE void				setScArticulation(Scb::Articulation* articulation)	{ mJoint.setArticulation(&articulation->getScArticulation()); }
 

--- a/physx/source/physx/src/buffering/ScbBody.h
+++ b/physx/source/physx/src/buffering/ScbBody.h
@@ -261,7 +261,7 @@ public:
 	PX_INLINE		void				syncState();
 	PX_INLINE		void				syncCollisionWriteThroughState();
 
-	static size_t getScOffset()	{ return reinterpret_cast<size_t>(&reinterpret_cast<Body*>(0)->mBodyCore);	}
+	static size_t getScOffset()	{ return PX_OFFSET_OF(Body, mBodyCore);	}
 	
 	/**
 	\brief Shadowed method of #Scb::Base::markUpdated() to store the buffered property flags in a separate location (ran out of flag space)

--- a/physx/source/physx/src/buffering/ScbConstraint.h
+++ b/physx/source/physx/src/buffering/ScbConstraint.h
@@ -122,7 +122,7 @@ public:
 	PX_FORCE_INLINE static Constraint&			fromSc(Core &a)					{ return *reinterpret_cast<Constraint*>(reinterpret_cast<PxU8*>(&a)-getScOffset()); }
 	PX_FORCE_INLINE static const Constraint&	fromSc(const Core &a)			{ return *reinterpret_cast<const Constraint*>(reinterpret_cast<const PxU8*>(&a)-getScOffset()); }
 
-	static size_t getScOffset()	{ return reinterpret_cast<size_t>(&reinterpret_cast<Constraint*>(0)->mConstraint);	}
+	static size_t getScOffset()	{ return PX_OFFSET_OF(Constraint, mConstraint);	}
 
 private:
 	Core		mConstraint;

--- a/physx/source/physx/src/buffering/ScbRigidStatic.h
+++ b/physx/source/physx/src/buffering/ScbRigidStatic.h
@@ -98,7 +98,7 @@ public:
 	//---------------------------------------------------------------------------------
 	PX_INLINE void						syncState();
 
-	static size_t getScOffset()	{ return reinterpret_cast<size_t>(&reinterpret_cast<RigidStatic*>(0)->mStatic);	}
+	static size_t getScOffset()	{ return PX_OFFSET_OF(RigidStatic, mStatic);	}
 
 	PX_FORCE_INLINE Sc::StaticCore&		getScStatic()				{	return mStatic; }
 

--- a/physx/source/physx/src/buffering/ScbScene.h
+++ b/physx/source/physx/src/buffering/ScbScene.h
@@ -334,7 +334,7 @@ namespace Scb
 		void								switchRigidToNoSim(Scb::RigidObject&, bool isDynamic);
 		void								switchRigidFromNoSim(Scb::RigidObject&, bool isDynamic);
 
-		static size_t						getScOffset()	{ return reinterpret_cast<size_t>(&reinterpret_cast<Scene*>(0)->mScene); }
+		static size_t						getScOffset()	{ return PX_OFFSET_OF(Scene, mScene); }
 
 #if PX_SUPPORT_PVD
 		PX_FORCE_INLINE	Vd::ScbScenePvdClient&			getScenePvdClient()			{ return mScenePvdClient; }

--- a/physx/source/physx/src/buffering/ScbShape.h
+++ b/physx/source/physx/src/buffering/ScbShape.h
@@ -208,7 +208,7 @@ public:
 
 	template<bool sync> PX_FORCE_INLINE void checkUpdateOnRemove(Scene* s);
 
-	static size_t getScOffset()	{ return reinterpret_cast<size_t>(&reinterpret_cast<Shape*>(0)->mShape);	}
+	static size_t getScOffset()	{ return PX_OFFSET_OF(Shape, mShape);	}
 
 private:
 					bool				setMaterialsHelper(PxMaterial* const* materials, PxU16 materialCount);

--- a/physx/source/simulationcontroller/include/ScBodyCore.h
+++ b/physx/source/simulationcontroller/include/ScBodyCore.h
@@ -191,10 +191,11 @@ namespace Sc
 
 		PX_FORCE_INLINE SimStateData*		getSimStateData_Unchecked()			const	{ return mSimStateData; }
 
+		static PX_FORCE_INLINE size_t		getCoreOffset()								{ return PX_OFFSET_OF(BodyCore, mCore); }
+
 		static PX_FORCE_INLINE BodyCore&	getCore(PxsBodyCore& core)
 		{ 
-			size_t offset = PX_OFFSET_OF_RT(BodyCore, mCore);
-			return *reinterpret_cast<BodyCore*>(reinterpret_cast<PxU8*>(&core) - offset); 
+			return *reinterpret_cast<BodyCore*>(reinterpret_cast<PxU8*>(&core) - getCoreOffset()); 
 		}
 
 		void				setKinematicLink(const bool value);

--- a/physx/source/simulationcontroller/include/ScShapeCore.h
+++ b/physx/source/simulationcontroller/include/ScShapeCore.h
@@ -112,12 +112,13 @@ namespace Sc
 		PX_FORCE_INLINE	PxShapeFlags				getFlags()									const	{ return PxShapeFlags(mCore.mShapeFlags);	}
 		PX_FORCE_INLINE	void						setFlags(PxShapeFlags f)							{ mCore.mShapeFlags = f;					}
 
+		static PX_FORCE_INLINE size_t				getCoreOffset()										{ return PX_OFFSET_OF(ShapeCore, mCore);	}
+
 		PX_FORCE_INLINE const PxsShapeCore&			getCore()									const	{ return mCore;								}
 
 		static PX_FORCE_INLINE ShapeCore&			getCore(PxsShapeCore& core)			
 		{ 
-			size_t offset = PX_OFFSET_OF(ShapeCore, mCore);
-			return *reinterpret_cast<ShapeCore*>(reinterpret_cast<PxU8*>(&core) - offset); 
+			return *reinterpret_cast<ShapeCore*>(reinterpret_cast<PxU8*>(&core) - getCoreOffset()); 
 		}	
 
 	protected:

--- a/physx/source/simulationcontroller/include/ScStaticCore.h
+++ b/physx/source/simulationcontroller/include/ScStaticCore.h
@@ -60,6 +60,7 @@ namespace Sc
 						void				setActor2World(const PxTransform& actor2World);
 
 		PX_FORCE_INLINE	PxsRigidCore&		getCore()				{ return mCore;				}
+		static PX_FORCE_INLINE size_t		getCoreOffset()			{ return PX_OFFSET_OF(StaticCore, mCore);	}
 
 											StaticCore(const PxEMPTY) :	RigidCore(PxEmpty), mCore(PxEmpty) {}
 		static			void				getBinaryMetaData(PxOutputStream& stream);


### PR DESCRIPTION
The current code dereferences null pointers to compute an offset,
which has undefined behaviour. This patch changes that code to either
use the PX_OFFSET_OF macro (which is already used elsewhere for this
purpose, and which has well-defined behaviour on many popular
platforms), and creates a number of static member functions to expose
these values.