### PR TITLE
Fix index computation in Gu::HeightField::computeCellCoordinates from PxF32 to PxU32

### DIFF
--- a/physx/source/geomutils/src/hf/GuHeightField.cpp
+++ b/physx/source/geomutils/src/hf/GuHeightField.cpp
@@ -703,7 +703,7 @@ PxU32 Gu::HeightField::computeCellCoordinates(PxReal x, PxReal z, PxReal& fracX,
 	PX_ASSERT(x >= 0.0f && x < PxF32(mData.rows));
 	PX_ASSERT(z >= 0.0f && z < PxF32(mData.columns));
 
-	const PxU32 vertexIndex = PxU32(x * (mData.nbColumns) + z);
+	const PxU32 vertexIndex = PxU32(x) * mData.columns + PxU32(z);
 	PX_ASSERT(vertexIndex < (mData.rows)*(mData.columns));
 
 	return vertexIndex;


### PR DESCRIPTION
The vertex index in Gu::HeightField::computeCellCoordinates is computed in 32-bit floating point and the lack of precision causes indexing errors. Indexing errors of 1 start appearing on GuHeightField with a size between 4000x4000 and 5000x5000.
For example a GuHeighField with 8193 columns can see x = 5720 and z = 7826 which means vertexIndex should be 5720*8193+7826 = 46871786 but the floating point representation only allows 46871784 or 46871788 as values.
Wrong indexing causes issues when trying to compute normals or determine the orientation of the tesselation of a  GuHeightField.