### PR TITLE
PxProfiler: Add a logging interface.

### DIFF
--- a/physx/include/common/PxProfileZone.h
+++ b/physx/include/common/PxProfileZone.h
@@ -40,10 +40,14 @@
 	#define PX_PROFILE_STOP_CROSSTHREAD(x, y)							\
 		if(PxGetProfilerCallback())										\
 			PxGetProfilerCallback()->zoneEnd(NULL, x, true, y)
+	#define PX_PROFILE_MSG(verbosity, format, ...)						\
+		if (PxGetProfilerCallback())									\
+			PxGetProfilerCallback()->logMessage(verbosity, format,  ##__VA_ARGS__)
 #else
 	#define PX_PROFILE_ZONE(x, y)
 	#define PX_PROFILE_START_CROSSTHREAD(x, y)
 	#define PX_PROFILE_STOP_CROSSTHREAD(x, y)
+	#define PX_PROFILE_MSG(verbosity, format, ...)
 #endif
 
 #define PX_PROFILE_POINTER_TO_U64(pointer) static_cast<uint64_t>(reinterpret_cast<size_t>(pointer))

--- a/physx/source/pvd/src/PxPvdImpl.cpp
+++ b/physx/source/pvd/src/PxPvdImpl.cpp
@@ -394,6 +394,13 @@ void PvdImpl::zoneEnd(void* /*profilerData*/, const char* eventName, bool detach
 	}
 #endif
 }
+
+void PvdImpl::logMessage(uint8_t /* verbosity */, const char /* *format */, ...)
+{
+	/* Unused */
+}
+
+
 } // pvd
 
 } // physx

--- a/physx/source/pvd/src/PxPvdImpl.h
+++ b/physx/source/pvd/src/PxPvdImpl.h
@@ -192,6 +192,8 @@ class PvdImpl : public PsPvd, public shdfnd::UserAllocated
 
 	virtual void zoneEnd(void* profilerData, const char *eventName, bool detached, uint64_t contextId);
 
+	virtual void logMessage(uint8_t verbosity, const char *format, ...);
+
   private:
 	void sendTransportInitialization();
 

--- a/pxshared/include/foundation/PxProfiler.h
+++ b/pxshared/include/foundation/PxProfiler.h
@@ -66,6 +66,14 @@ public:
 	\note eventName plus contextId can be used to uniquely match up start and end of a zone.
 	*/
 	virtual void zoneEnd(void* profilerData, const char* eventName, bool detached, uint64_t contextId) = 0;
+
+	/**
+	\brief print a log message via backend logging systems.
+	\param[in] verbosity	The verbosity levels of the backend logging systems are reserved. (i.e. Fatal = 1, Error = 2, Warning = 3, ...)
+	\param[in] format		A formatted text
+	\param[in] ...			Variable arguments used in format
+	*/
+	virtual void logMessage(uint8_t verbosity, const char* format, ...) = 0;
 };
 
 class PxProfileScoped


### PR DESCRIPTION
It's necesssary to see PhysX behaviors with the main system in a chronogolical order.
The following interface is designed for printing log messages via a backend logging system.

void PxProfilerCallback::logMessage(uint8_t verbosity, const char* format, ...)

The verbosity is the level of backend logging systems.
(i.e Fatal = 1, Error = 2, Warning = 3 ...)

Usages:
PX_PROFILE_MSG(level, "PhysX log message - %d", var);